### PR TITLE
Fix missing TF State

### DIFF
--- a/.github/actions/init/action.yaml
+++ b/.github/actions/init/action.yaml
@@ -29,7 +29,7 @@ runs:
       run: |
         echo 'terraform {' > ${{ inputs.tf_backend_file_name }}
         echo '  backend "azurerm" {' >> ${{ inputs.tf_backend_file_name }}
-        echo 'resource_group_name="rg-Icebreaker-int-01"' >> ${{ inputs.tf_backend_file_name }}
+        echo 'resource_group_name="rg-IcebreakerTf-int-01"' >> ${{ inputs.tf_backend_file_name }}
         echo 'storage_account_name="stzgminttficebreaker01"' >> ${{ inputs.tf_backend_file_name }}
         echo 'container_name="tfstate"' >> ${{ inputs.tf_backend_file_name }}
         echo 'key="int.tfstate"' >> ${{ inputs.tf_backend_file_name }}


### PR DESCRIPTION
The Resource Group Deployment uses a "Complete" mode. Therefore any ressource present will be deleted. Including storage acocunt used for state. Erge use storage account in different rg