### PR TITLE
Fix Path issues due to docker

### DIFF
--- a/.github/workflows/apply.yaml
+++ b/.github/workflows/apply.yaml
@@ -30,9 +30,15 @@ jobs:
       id: tf-outputs
       with:
         path: ${{ env.TF_DIR }}
+    - name: Resolve Path
+      shell: pwsh
+      working-directory: ${{ env.TF_DIR }}
+      run: |
+        $path = Resolve-Path ${{ steps.tf-outputs.outputs.manifest_path }}
+        Write-Output "APP_PACKAGE_PATH=path" >> $env:GITHUB_ENV
     - name: Upload App Package
       uses: actions/upload-artifact@v2
       with:
         name: App-Package
-        path: ${{ steps.tf-outputs.outputs.manifest_path }}
+        path: ${{ env.APP_PACKAGE_PATH }}
         if-no-files-found: error

--- a/Deployment/terraform/manifest.tf
+++ b/Deployment/terraform/manifest.tf
@@ -51,9 +51,9 @@ resource "local_file" "manifest" {
   })
 }
 
-data "archive_file" "dotfiles" {
+data "archive_file" "app_package" {
   type        = "zip"
-  output_path = "${path.module}/../manifest.zip"
+  output_path = "${path.module}/manifest.zip"
   source_dir  = "${path.module}/tmp"
   depends_on = [
     local_file.logo, local_file.manifest

--- a/Deployment/terraform/outputs.tf
+++ b/Deployment/terraform/outputs.tf
@@ -1,3 +1,3 @@
 output "manifest_path" {
-  value = abspath(data.archive_file.dotfiles.output_path)
+  value = data.archive_file.app_package.output_path
 }


### PR DESCRIPTION
The tf actions are running in docker. So paths are diffrent in there. Upload-Artifact does not support paths with "." or ".." so we resolve path with pwsh.