### PR TITLE
Fix Serverless Option

### DIFF
--- a/Deployment/azuredeploy.json
+++ b/Deployment/azuredeploy.json
@@ -195,7 +195,10 @@
         "KeyVaultURI": "[concat('https://', variables('keyVaultName'), '.vault.azure.net')]",
         "appInsightsName": "[variables('baseResourceName')]",
         "appHostingPlanName": "[variables('baseResourceName')]",
-        "sharedSkus": [ "Free", "Shared" ],
+        "sharedSkus": [
+            "Free",
+            "Shared"
+        ],
         "isSharedPlan": "[contains(variables('sharedSkus'), parameters('sku'))]",
         "skuFamily": "[if(equals(parameters('sku'), 'Shared'), 'D', take(parameters('sku'), 1))]",
         "skuName": "[if(variables('isSharedPlan'), concat(variables('skuFamily'),'1'), concat(variables('skuFamily'), parameters('planSize')))]",
@@ -353,7 +356,7 @@
                             "value": "false"
                         },
                         {
-                            "name": "cosmosDbServerless",
+                            "name": "CosmosDbServerless",
                             "value": "[parameters('cosmosDbServerless')]"
                         }
                     ],

--- a/Source/Icebreaker/Helpers/IcebreakerBotDataProvider.cs
+++ b/Source/Icebreaker/Helpers/IcebreakerBotDataProvider.cs
@@ -261,7 +261,7 @@ namespace Icebreaker.Helpers
 
             RequestOptions requestOptions;
             bool useSharedOffer;
-            if (CloudConfigurationManager.GetSetting("CosmosDbServerless").Equals("True", StringComparison.OrdinalIgnoreCase))
+            if ("True".Equals(CloudConfigurationManager.GetSetting("CosmosDbServerless"), StringComparison.OrdinalIgnoreCase))
             {
                 // ServerLess doesnt support Throughput
                 requestOptions = null;

--- a/Source/Icebreaker/Helpers/IcebreakerBotDataProvider.cs
+++ b/Source/Icebreaker/Helpers/IcebreakerBotDataProvider.cs
@@ -261,7 +261,7 @@ namespace Icebreaker.Helpers
 
             RequestOptions requestOptions;
             bool useSharedOffer;
-            if (CloudConfigurationManager.GetSetting("DocumentDbServerless").Equals("True", StringComparison.OrdinalIgnoreCase))
+            if (CloudConfigurationManager.GetSetting("CosmosDbServerless").Equals("True", StringComparison.OrdinalIgnoreCase))
             {
                 // ServerLess doesnt support Throughput
                 requestOptions = null;


### PR DESCRIPTION
The Serverless Option used two different Setting names.
Furthermore avoided NullReference when the serverlessoption is just not set so defaults to false.

fixes #36 